### PR TITLE
update to new class name - milestoneTracker

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var iri = com.iota.iri;
-var snapshot = IOTA.milestone.latestSnapshot;
+var snapshot = IOTA.milestoneTracker.latestSnapshot;
 
 var Snapshot = Java.type("com.iota.iri.Snapshot");
 var stateField = Snapshot.class.getDeclaredField("state");


### PR DESCRIPTION
the `milestone` class name will be changed to `milestoneTracker` in IRI - see https://github.com/iotaledger/iri/commit/22709d1d24e60518cc771a0475854b927c36ca9d#diff-7d46bf40891fe5255d868be867d0ede9, this will break this module.

(not to be merged until the changes are released)

@hmoog FYI.